### PR TITLE
Update for compat with zig 0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,7 +190,7 @@ tags
 
 ### zig ###
 # Zig programming language
-
+.zig-cache/
 zig-cache/
 zig-out/
 build/

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ The [Nim implementation](https://github.com/SolitudeSF/blurhash) of BlurHash was
 I also used [Zig Image Library](https://github.com/zigimg/zigimg) (aka zigimg) as a dependency to make my life a lot easier. Dependency management is handled with the official Zig package manager (see build.zig.zon)
 
 # Usage
-This code targets Zig 0.12.0 which is the latest stable release as of the code being written, so ensure that is installed before trying to run this.
+This code targets Zig 0.13.0 which is the latest stable release as of the code being written, so ensure that is installed before trying to run this.
 
-The dependency libraries are pinned to versions which work with Zig 0.12.0
+The dependency libraries are pinned to versions which work with Zig 0.13.0
 
 ## Running on the command line
 ```

--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "blurhash-zig",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -29,7 +29,7 @@ pub fn build(b: *std.Build) void {
     run_step.dependOn(&run_cmd.step);
 
     const unit_tests = b.addTest(.{
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,4 +1,4 @@
-.{ .name = "blurhash-zig", .version = "0.2.0", .minimum_zig_version = "0.13.0", .dependencies = .{
+.{ .name = "blurhash-zig", .version = "0.3.0", .minimum_zig_version = "0.13.0", .dependencies = .{
     .zigimg = .{
         .url = "https://github.com/zigimg/zigimg/archive/cbb0c64caffd5b02863aadd62bab48cef7f86ceb.tar.gz",
         .hash = "1220c0980dc05816b12a8188546b4847bcf38e5e99defc0ea79a8d6bd4809049a029",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
-.{ .name = "blurhash-zig", .version = "0.2.0", .minimum_zig_version = "0.12.0", .dependencies = .{
+.{ .name = "blurhash-zig", .version = "0.2.0", .minimum_zig_version = "0.13.0", .dependencies = .{
     .zigimg = .{
-        .url = "https://github.com/zigimg/zigimg/archive/637974e2d31dcdbc33f1e9cc8ffb2e46abd2e215.tar.gz",
-        .hash = "122012026c3a65ff1d4acba3b3fe80785f7cee9c6b4cdaff7ed0fbf23b0a6c803989",
+        .url = "https://github.com/zigimg/zigimg/archive/cbb0c64caffd5b02863aadd62bab48cef7f86ceb.tar.gz",
+        .hash = "1220c0980dc05816b12a8188546b4847bcf38e5e99defc0ea79a8d6bd4809049a029",
     },
 }, .paths = .{
     "LICENSE",


### PR DESCRIPTION
- Update build
- re-pin dependencies
- update readme
- update .gitignore to reflect new cache directory
- Bump version in zon file